### PR TITLE
remove number from ecospold filenames

### DIFF
--- a/ensemble/change_ecospold_file_names.py
+++ b/ensemble/change_ecospold_file_names.py
@@ -1,22 +1,22 @@
 #!/usr/bin/env python
-
-import argparse
-import os
-
 """When ecoinvent 3.5 was released, the file names have changed.
 There has been some number added to the start of the filename,
 but it can be ignored. This script takes the file_names from
 #####_uuidAcitivity_uuidProduct to uuidAcitivity_uuidProduct
 
 Warning: Currently does not do sensibility checks!
-Use at you own responsibility! (and make a back up of you data!)"""
+Use at you own responsibility! (and make a back up of you data!)
+"""
 
+
+import argparse
+import os
 
 
 def change_file_name(spoldfile_dir):
 
     print("Target directory is ", spoldfile_dir)
-    user_choice = input("Is this correct? y/n ")
+    user_choice = raw_input("Is this correct? y/n ")
     while user_choice not in ['y','n']:
         user_choice = raw_input("Invalid option, please choose again \n"\
                              "Is this correct? y/n ")

--- a/ensemble/change_ecospold_file_names.py
+++ b/ensemble/change_ecospold_file_names.py
@@ -2,20 +2,19 @@
 
 import argparse
 import os
-import numpy as np
+
 """When ecoinvent 3.5 was released, the file names have changed.
-There has been some number added to the start of the filename, 
-but it can be ignored. This script takes the file_names from 
+There has been some number added to the start of the filename,
+but it can be ignored. This script takes the file_names from
 #####_uuidAcitivity_uuidProduct to uuidAcitivity_uuidProduct
 
-Warning: Currently does not do sensibility checks! 
-Use at you own responsibility! (and make a back up of you data!)
-"""
+Warning: Currently does not do sensibility checks!
+Use at you own responsibility! (and make a back up of you data!)"""
 
 
 
 def change_file_name(spoldfile_dir):
-    
+
     print("Target directory is ", spoldfile_dir)
     user_choice = input("Is this correct? y/n ")
     while user_choice not in ['y','n']:
@@ -36,10 +35,10 @@ def change_file_name(spoldfile_dir):
     os.chdir(spoldfile_dir)
     spoldfiles = os.listdir()
     
-    for file in spoldfiles:
-        #print(file)
-        if len(file.split("_")) == 3:
-            os.rename(file, "_".join(file.split("_")[1:]))
+    for sfile in spoldfiles:
+        #print(sfile)
+        if len(sfile.split("_")) == 3:
+            os.rename(file, "_".join(sfile.split("_")[1:]))
     
     print("file names changed")
     print("changeing back to working directory")

--- a/ensemble/change_ecospold_file_names.py
+++ b/ensemble/change_ecospold_file_names.py
@@ -3,16 +3,13 @@
 import argparse
 import os
 import numpy as np
-"""
-
-When ecoinvent 3.5 was released, the file names have changed.
+"""When ecoinvent 3.5 was released, the file names have changed.
 There has been some number added to the start of the filename, 
 but it can be ignored. This script takes the file_names from 
 #####_uuidAcitivity_uuidProduct to uuidAcitivity_uuidProduct
 
 Warning: Currently does not do sensibility checks! 
 Use at you own responsibility! (and make a back up of you data!)
-
 """
 
 
@@ -32,8 +29,7 @@ def change_file_name(spoldfile_dir):
             return
         else:
             spoldfile_dir = var
-
-    
+            
     print("saving current working directory")
     cwd = os.getcwd() #get cwd
     print("changing to target dir")
@@ -53,13 +49,12 @@ def change_file_name(spoldfile_dir):
 
 
 def ParseArgs():
-    '''
-    ParsArgs parser the command line options 
+    '''ParsArgs parser the command line options
     and returns them as a Namespace object
     '''
     print("Parsing arguments...")
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d","--dir", type=str, dest='target_dir', 
+    parser.add_argument("-d","--dir", type=str, dest='target_dir',
                         default="/home/jakobs/data/ecoinvent/ei35_unlinked/datasets",
                         help="Directory containing the spoldfiles to be"\
                         "renamed")

--- a/ensemble/change_ecospold_file_names.py
+++ b/ensemble/change_ecospold_file_names.py
@@ -22,10 +22,10 @@ def change_file_name(spoldfile_dir):
     print("Target directory is ", spoldfile_dir)
     user_choice = input("Is this correct? y/n ")
     while user_choice not in ['y','n']:
-        user_choice = input("Invalid option, please choose again \n"\
+        user_choice = raw_input("Invalid option, please choose again \n"\
                              "Is this correct? y/n ")
     if user_choice == 'n':
-        var = input("please provide the target correct target dir\n"\
+        var = raw_input("please provide the target correct target dir\n"\
                     "Or type q to quit! ")
         if var in ["q","Q"]:
             print("Quiting... Bye!")
@@ -40,7 +40,7 @@ def change_file_name(spoldfile_dir):
     os.chdir(spoldfile_dir)
     spoldfiles = os.listdir()
     
-    for i,file in enumerate(spoldfiles[:]):
+    for file in spoldfiles:
         #print(file)
         if len(file.split("_")) == 3:
             os.rename(file, "_".join(file.split("_")[1:]))

--- a/ensemble/change_ecospold_file_names.py
+++ b/ensemble/change_ecospold_file_names.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import numpy as np
+"""
+
+When ecoinvent 3.5 was released, the file names have changed.
+There has been some number added to the start of the filename, 
+but it can be ignored. This script takes the file_names from 
+#####_uuidAcitivity_uuidProduct to uuidAcitivity_uuidProduct
+
+Warning: Currently does not do sensibility checks! 
+Use at you own responsibility! (and make a back up of you data!)
+
+"""
+
+
+
+def change_file_name(spoldfile_dir):
+    
+    print("Target directory is ", spoldfile_dir)
+    user_choice = input("Is this correct? y/n ")
+    while user_choice not in ['y','n']:
+        user_choice = input("Invalid option, please choose again \n"\
+                             "Is this correct? y/n ")
+    if user_choice == 'n':
+        var = input("please provide the target correct target dir\n"\
+                    "Or type q to quit! ")
+        if var in ["q","Q"]:
+            print("Quiting... Bye!")
+            return
+        else:
+            spoldfile_dir = var
+
+    
+    print("saving current working directory")
+    cwd = os.getcwd() #get cwd
+    print("changing to target dir")
+    os.chdir(spoldfile_dir)
+    spoldfiles = os.listdir()
+    
+    for i,file in enumerate(spoldfiles[:]):
+        #print(file)
+        if len(file.split("_")) == 3:
+            os.rename(file, "_".join(file.split("_")[1:]))
+    
+    print("file names changed")
+    print("changeing back to working directory")
+    os.chdir(cwd)#change back to originial wd
+    print("Done!")
+    return 
+
+
+def ParseArgs():
+    '''
+    ParsArgs parser the command line options 
+    and returns them as a Namespace object
+    '''
+    print("Parsing arguments...")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-d","--dir", type=str, dest='target_dir', 
+                        default="/home/jakobs/data/ecoinvent/ei35_unlinked/datasets",
+                        help="Directory containing the spoldfiles to be"\
+                        "renamed")
+    
+    args = parser.parse_args()
+    
+    print("Arguments parsed.")
+    return args
+
+
+if __name__=="__main__":
+    args = ParseArgs()
+    change_file_name(args.target_dir)


### PR DESCRIPTION
Short scripts that takes a datasets directory as input, and removes the number from the ecospold files name:
####_activityID_productID --> activityID_productID
Note this only works for the above format (i.e. 3.5)
Use it as you see fit