### PR TITLE
Region concordance

### DIFF
--- a/ensemble/concordance/regions_concordance.py
+++ b/ensemble/concordance/regions_concordance.py
@@ -127,6 +127,13 @@ class RegionConcordance(object):
                 row = self.RoW(excluded)
                 desireCode = self.countryConcord.set_index('Code').loc[
                                     row,'DESIRE code'].unique().tolist()
+                #Check for provinces in exlcuded. If provinces exist in ecluded
+                #the entire country needs to be excluded to avoid double
+                #counting. (I.e. the country is already included when the
+                #province is called.)
+                excl_list = self.countryConcord.set_index('Code').loc[excluded,
+                                    'DESIRE code'].tolist()
+                desireCode = [x for x in desireCode if not x in excl_list]
                 #get rid of potential nans from islands as Guernsey or Jersey
                 #that originate from the row process but are not (ei3.5 in the
                 #process data.

--- a/ensemble/concordance/regions_concordance.py
+++ b/ensemble/concordance/regions_concordance.py
@@ -135,7 +135,7 @@ class RegionConcordance(object):
             else:
                 print('No region given to exlude from Globally\n\
                 Returning GLOBAL')
-                desireCode = self.returnDict['GLO']
+                desireCode = self.regionDict['GLO']
         return desireCode
 
 


### PR DESCRIPTION
Fixed a typo bug that caused a problem when calling the region 'GLO'
Fixed a double counting issue when calling RoW without a province (e.g. CA-QC'). The entire country is now excluded from RoW to avoid double counting, because the province is mapped to the entire country.